### PR TITLE
Move mocha to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "http://timssweeney.com/async-astar/",
   "dependencies": {
-    "mocha": "^2.1.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
@@ -28,6 +27,7 @@
     "grunt-docker": "0.0.9",
     "grunt-jsbeautifier": "^0.2.8",
     "grunt-release": "^0.11.0",
-    "grunt-simple-mocha": "^0.4.0"
+    "grunt-simple-mocha": "^0.4.0",
+    "mocha": "^2.1.0"
   }
 }


### PR DESCRIPTION
There are currently audit warnings for `async-astar` due to the outdated `mocha` dependency. It also shouldn't be in `dependencies` as it is only used for testing, so I've moved it to `devdependencies`

```
  Critical        Command Injection                             
                                                                
  Package         growl                                         
                                                                
  Patched in      >=1.10.2                                      
                                                                
  Dependency of   async-astar                                   
                                                                
  Path            async-astar > mocha > growl                   
                                                                
  More info       https://nodesecurity.io/advisories/146        
                                                                
                                                                
  High            Regular Expression Denial of Service          
                                                                
  Package         minimatch                                     
                                                                
  Patched in      >=3.0.2                                       
                                                                
  Dependency of   async-astar                                   
                                                                
  Path            async-astar > mocha > glob > minimatch        
                                                                
  More info       https://nodesecurity.io/advisories/118        
                                                                
                                                                
  Low             Regular Expression Denial of Service          
                                                                
  Package         debug                                         
                                                                
  Patched in      >= 2.6.9 < 3.0.0 || >= 3.1.0                  
                                                                
  Dependency of   async-astar                                   
                                                                
  Path            async-astar > mocha > debug                   
                                                                
  More info       https://nodesecurity.io/advisories/534        
```